### PR TITLE
Add GitHub Actions workflow for packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build Releases
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm install
+      - name: Build application
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            npm run build:win
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            npm run build:mac
+          else
+            sudo apt-get update
+            sudo apt-get install -y libarchive-tools
+            npm run build:linux
+          fi
+        shell: bash
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ runner.os }}-artifacts
+          path: dist/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - run: npm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           fi
         shell: bash
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-artifacts
           path: dist/**

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,0 +1,41 @@
+# Code Signing Certificates
+
+This project uses Electron Builder to produce installer packages. Signing the
+packages requires certificate files and corresponding passwords. These files are
+not stored in the repository. Instead, they can be added later through GitHub
+Actions secrets.
+
+## Adding Certificates
+
+1. Convert your signing certificates to base64 strings so they can be stored as
+   secrets. For example:
+   ```bash
+   base64 -w0 path/to/cert.p12 > cert.p12.b64
+   ```
+2. In the GitHub repository, navigate to **Settings** ➜ **Secrets and
+   variables** ➜ **Actions**.
+3. Create secrets for each certificate and password, e.g.:
+   - `WIN_CERT` – the base64 string of the Windows `.p12` file
+   - `WIN_CERT_PASSWORD` – the password for the `.p12`
+   - `MAC_CERT` – the base64 string of the macOS `.p12` file
+   - `MAC_CERT_PASSWORD` – the password for the `.p12`
+
+## Using Secrets in the Workflow
+
+In `.github/workflows/build.yml`, add steps before the build to decode the
+secrets and use them for signing. Example:
+
+```yaml
+- name: Set up code signing certificates
+  run: |
+    echo "$WIN_CERT" | base64 --decode > win_cert.p12
+    echo "$MAC_CERT" | base64 --decode > mac_cert.p12
+  shell: bash
+  env:
+    WIN_CERT: ${{ secrets.WIN_CERT }}
+    MAC_CERT: ${{ secrets.MAC_CERT }}
+```
+
+Then configure `electron-builder` via environment variables or the
+`package.json` `build` section to reference these certificate files and
+passwords. Refer to the Electron Builder documentation for detailed options.


### PR DESCRIPTION
## Summary
- add GHA workflow to build Windows, macOS, and Linux release artifacts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c812120d4832b80d9f899e60d464a