### PR TITLE
Add configurable status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ npm run build
 ```
 
 See `package.json` for platform-specific build scripts.
+
+## Configuration
+
+Server definitions live in a JSON config file. Each server can specify a
+`statusEndpoint` used to check its HTTP status. If omitted, the application
+defaults to `/get_server_time`.

--- a/index.html
+++ b/index.html
@@ -453,6 +453,10 @@
                     <input type="number" id="server-http-port" required>
                 </div>
                 <div class="form-group">
+                    <label for="server-status-endpoint">Status Endpoint:</label>
+                    <input type="text" id="server-status-endpoint" value="/get_server_time" required>
+                </div>
+                <div class="form-group">
                     <label for="server-screen-name">Screen Name:</label>
                     <input type="text" id="server-screen-name" required>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "fs-extra": "^11.3.0",
-        "node-fetch": "^3.3.2",
         "ssh2": "^1.16.0"
       },
       "devDependencies": {
@@ -1746,15 +1745,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2396,29 +2386,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -2497,18 +2464,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -3630,44 +3585,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/nopt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
@@ -4778,15 +4695,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "node-fetch": "^3.3.2",
     "ssh2": "^1.16.0",
     "@xterm/xterm": "^5.5.0",
     "@xterm/addon-fit": "^0.10.0"

--- a/renderer.js
+++ b/renderer.js
@@ -2,7 +2,8 @@
 const { ipcRenderer } = require('electron');
 const { Terminal } = require('@xterm/xterm');
 const { FitAddon } = require('@xterm/addon-fit');
-const fetch = require('node-fetch');
+const http = require('http');
+const https = require('https');
 
 let config;
 let editingServer = null;
@@ -104,14 +105,28 @@ async function checkHttpEndpoint(serverName) {
   const serverConfig = config[serverName];
   const endpoint = serverConfig.statusEndpoint || '/get_server_time';
   const sanitizedEndpoint = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
-  const url = `http://${serverConfig.host}:${serverConfig.httpPort}${sanitizedEndpoint}`;
-  try {
-    const response = await fetch(url, { timeout: 5000 });
-    return response.ok;
-  } catch (error) {
-    console.error(`HTTP check failed for ${serverName}:`, error);
-    return false;
-  }
+  const urlString = `http://${serverConfig.host}:${serverConfig.httpPort}${sanitizedEndpoint}`;
+  return new Promise((resolve) => {
+    try {
+      const url = new URL(urlString);
+      const lib = url.protocol === 'https:' ? https : http;
+      const req = lib.get(url, (res) => {
+        res.resume(); // consume data
+        resolve(res.statusCode >= 200 && res.statusCode < 300);
+      });
+      req.on('error', (error) => {
+        console.error(`HTTP check failed for ${serverName}:`, error);
+        resolve(false);
+      });
+      req.setTimeout(5000, () => {
+        req.destroy();
+        resolve(false);
+      });
+    } catch (error) {
+      console.error(`HTTP check setup failed for ${serverName}:`, error);
+      resolve(false);
+    }
+  });
 }
 
 async function updateServerStatus(serverName) {

--- a/renderer.js
+++ b/renderer.js
@@ -102,7 +102,9 @@ async function saveConfig() {
 }
 async function checkHttpEndpoint(serverName) {
   const serverConfig = config[serverName];
-  const url = `http://${serverConfig.host}:${serverConfig.httpPort}/get_server_time`;
+  const endpoint = serverConfig.statusEndpoint || '/get_server_time';
+  const sanitizedEndpoint = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+  const url = `http://${serverConfig.host}:${serverConfig.httpPort}${sanitizedEndpoint}`;
   try {
     const response = await fetch(url, { timeout: 5000 });
     return response.ok;
@@ -272,7 +274,8 @@ function createServerControls(serverName) {
 
   const infoElement = document.createElement('div');
   infoElement.className = 'server-info';
-  infoElement.textContent = `SSH: ${serverConfig.username}@${serverConfig.host}, HTTP: ${serverConfig.host}:${serverConfig.httpPort}`;
+  const endpointInfo = serverConfig.statusEndpoint || '/get_server_time';
+  infoElement.textContent = `SSH: ${serverConfig.username}@${serverConfig.host}, HTTP: ${serverConfig.host}:${serverConfig.httpPort}${endpointInfo}`;
   container.appendChild(infoElement);
 
   const statusContainer = document.createElement('div');
@@ -333,6 +336,7 @@ function openServerModal(serverName = null) {
     form.elements['server-host'].value = server.host;
     form.elements['server-username'].value = server.username;
     form.elements['server-http-port'].value = server.httpPort;
+    form.elements['server-status-endpoint'].value = server.statusEndpoint || '/get_server_time';
     form.elements['server-screen-name'].value = server.screen_name;
     form.elements['server-type'].value = server.server_script ? 'script' : 'module';
     form.elements['server-script'].value = server.server_script || '';
@@ -348,6 +352,7 @@ function openServerModal(serverName = null) {
     form.elements['server-type'].value = 'script';
     form.elements['server-shell'].value = 'bash';
     form.elements['server-active'].checked = true;
+    form.elements['server-status-endpoint'].value = '/get_server_time';
   }
 
   updateServerTypeFields();
@@ -368,6 +373,7 @@ async function handleServerFormSubmit(event) {
     host: form.elements['server-host'].value,
     username: form.elements['server-username'].value,
     httpPort: parseInt(form.elements['server-http-port'].value, 10),
+    statusEndpoint: form.elements['server-status-endpoint'].value || '/get_server_time',
     screen_name: form.elements['server-screen-name'].value,
     shell: form.elements['server-shell'].value,
     active: form.elements['server-active'].checked

--- a/sshOperations.js
+++ b/sshOperations.js
@@ -24,6 +24,7 @@ class SSHOperations {
         const server = this.config[serverName];
         if (!server.httpPort) server.httpPort = 5000;
         if (!server.shell) server.shell = 'bash';
+        if (!server.statusEndpoint) server.statusEndpoint = '/get_server_time';
         if (!('active' in server)) server.active = true;
         if (!server.username) {
           console.warn(`Username not specified for server ${serverName}. Using current user.`);


### PR DESCRIPTION
## Summary
- allow each server to specify a `statusEndpoint` used when checking HTTP status
- show the endpoint in the UI and expose it in the server editor form
- default to `/get_server_time` when no endpoint is provided
- document the new option in the README

## Testing
- `npm run check-package`
- `node -c sshOperations.js && node -c renderer.js`


------
https://chatgpt.com/codex/tasks/task_e_684cee1aa940832bac82e82484b5d129