### PR TITLE
Remove duplicate saveConfig function

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -107,9 +107,6 @@ async function loadConfig() {
   config = await ipcRenderer.invoke('get-config');
 }
 
-async function saveConfig() {
-  await ipcRenderer.invoke('save-config', config);
-}
 
 async function fetchQueueState(serverName) {
   const serverConfig = config[serverName];


### PR DESCRIPTION
## Summary
- remove the early `saveConfig` definition so only the later one remains

## Testing
- `npm run check-package`


------
https://chatgpt.com/codex/tasks/task_e_6852ee8bbc10832b88cf6dc434ff080c