### PR TITLE
Fix async SSH key reload in import handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -134,7 +134,7 @@ ipcMain.handle('import-ssh-key', async () => {
     const sourcePath = result.filePaths[0];
     await fs.copyFile(sourcePath, sshKeyPath);
     await fs.chmod(sshKeyPath, 0o600); // Ensure correct permissions
-    sshOps.loadSSHKey(sshKeyPath);
+    await sshOps.loadSSHKey();
     return { success: true, message: 'SSH key imported successfully.' };
   } catch (error) {
     console.error('Error importing SSH key:', error);


### PR DESCRIPTION
## Summary
- ensure `import-ssh-key` awaits `loadSSHKey` when reloading the key

## Testing
- `npm run check-package`


------
https://chatgpt.com/codex/tasks/task_e_6852ee8d134c832b8c1634658fdbb554