### PR TITLE
Fix navigation for down servers

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -365,6 +365,12 @@ function openAndonPanel() {
 }
 
 function openServerWebview(serverName) {
+  const tabIcon = document.querySelector(
+    `.tab-item[data-server="${serverName}"] .tab-icon`
+  );
+  if (tabIcon && tabIcon.classList.contains('status-red')) {
+    return; // server down - don't change tabs
+  }
   const serverConfig = config[serverName];
   setActiveTab(serverName);
   const webview = document.getElementById('server-webview');


### PR DESCRIPTION
## Summary
- disallow navigation when clicking red/down server tabs

## Testing
- `npm run check-package`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852fb996d00832b93f6252bf668c658