### PR TITLE
Add WinRM support for Windows hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ npm run build
 ```
 
 See `package.json` for platform-specific build scripts.
+
+## Windows Support
+
+Servers running Windows can now be managed through [WinRM](https://learn.microsoft.com/en-us/windows/win32/winrm/windows-remote-management).  
+Add `"protocol": "winrm"` and a `"password"` field to the server configuration.  
+The application will execute commands via PowerShell remoting instead of SSH.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "fs-extra": "^11.3.0",
         "jsoneditor": "^10.2.0",
         "node-fetch": "^3.3.2",
+        "nodejs-winrm": "^1.1.3",
         "ssh2": "^1.16.0"
       },
       "devDependencies": {
@@ -3160,6 +3161,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js2xmlparser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+      "integrity": "sha512-CSOkdn0/GhRFwxnipmhXfqJ+FG6+wkWBi46kKSsPx6+j65176ZiQcrCYpg6K8x3iLbO4k3zScBnZ7I/L80dAtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^1.0.1"
+      }
+    },
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
@@ -3723,6 +3733,17 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/nodejs-winrm": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/nodejs-winrm/-/nodejs-winrm-1.1.3.tgz",
+      "integrity": "sha512-LyiLnfQJYNi74eb4xaUmtVR0OnSyvm01RcVNP5PKCGz+Z1yWdurPujyCab/80Cvv435GNUlR8sOJJ/Et35fG0A==",
+      "license": "MIT",
+      "dependencies": {
+        "js2xmlparser": "^3.0.0",
+        "uuid": "^3.3.2",
+        "xml2js": "^0.4.19"
+      }
+    },
     "node_modules/nopt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
@@ -4240,7 +4261,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/semver": {
@@ -4813,6 +4833,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/vanilla-picker": {
       "version": "2.12.3",
       "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.3.tgz",
@@ -4917,6 +4947,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -4926,6 +4978,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlcreate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+      "integrity": "sha512-Mbe56Dvj00onbnSo9J0qj/XlY5bfN9KidsOnpd5tRCsR3ekB3hyyNU9fGrTdqNT5ZNvv4BsA2TcQlignsZyVcw==",
+      "license": "Apache-2.0"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fs-extra": "^11.3.0",
     "jsoneditor": "^10.2.0",
     "node-fetch": "^3.3.2",
+    "nodejs-winrm": "^1.1.3",
     "ssh2": "^1.16.0"
   },
   "devDependencies": {

--- a/sshOperations.js
+++ b/sshOperations.js
@@ -1,4 +1,5 @@
 const { Client } = require('ssh2');
+const winrm = require('nodejs-winrm');
 const fs = require('fs').promises;
 const path = require('path');
 
@@ -95,6 +96,21 @@ class SSHOperations {
 
       debugLog(`${serverName} -> ${serverConfig.host}: ${command}`);
 
+      if (serverConfig.protocol === 'winrm') {
+        const port = serverConfig.port || 5985;
+        winrm
+          .runCommand(command, serverConfig.host, serverConfig.username,
+            serverConfig.password, port)
+          .then((output) => {
+            resolve({ success: true, output });
+          })
+          .catch((err) => {
+            console.error(`WinRM error for ${serverName}:`, err.message);
+            resolve({ success: false, sshDown: true });
+          });
+        return;
+      }
+
       const conn = new Client();
       let timer;
       let settled = false;
@@ -172,16 +188,30 @@ class SSHOperations {
     const screenLogPath = path.join('.afl', `${serverConfig.screen_name}.screenlog`);
     let startCommand;
 
-    if (serverConfig.server_module) {
-      let command = `python -m ${serverConfig.server_module}`;
-      if (serverConfig.conda_env) {
-        command = `conda activate ${serverConfig.conda_env};${command}`;
+    if (serverConfig.protocol === 'winrm') {
+      if (serverConfig.server_module) {
+        let command = `python -m ${serverConfig.server_module}`;
+        if (serverConfig.conda_env) {
+          command = `conda activate ${serverConfig.conda_env}; ${command}`;
+        }
+        startCommand = `Start-Process powershell -ArgumentList '${command}' -WindowStyle Hidden`;
+      } else if (serverConfig.server_script) {
+        startCommand = `Start-Process powershell -ArgumentList '${serverConfig.server_script}' -WindowStyle Hidden`;
+      } else {
+        return { success: false, error: 'Neither server_module nor server_script specified in config' };
       }
-      startCommand = `screen -d -m -L -Logfile $\{HOME}/${screenLogPath} -S ${serverConfig.screen_name} ${serverConfig.shell} -ci "${command}"`;
-    } else if (serverConfig.server_script) {
-      startCommand = `screen -d -m -L -Logfile $\{HOME}/${screenLogPath} -S ${serverConfig.screen_name} ${serverConfig.server_script}`;
     } else {
-      return { success: false, error: 'Neither server_module nor server_script specified in config' };
+      if (serverConfig.server_module) {
+        let command = `python -m ${serverConfig.server_module}`;
+        if (serverConfig.conda_env) {
+          command = `conda activate ${serverConfig.conda_env};${command}`;
+        }
+        startCommand = `screen -d -m -L -Logfile $\{HOME}/${screenLogPath} -S ${serverConfig.screen_name} ${serverConfig.shell} -ci "${command}"`;
+      } else if (serverConfig.server_script) {
+        startCommand = `screen -d -m -L -Logfile $\{HOME}/${screenLogPath} -S ${serverConfig.screen_name} ${serverConfig.server_script}`;
+      } else {
+        return { success: false, error: 'Neither server_module nor server_script specified in config' };
+      }
     }
 
     return this.executeCommand(serverName, startCommand);
@@ -189,7 +219,12 @@ class SSHOperations {
 
   async stopServer(serverName) {
     const serverConfig = this.config[serverName];
-    const stopCommand = `screen -X -S ${serverConfig.screen_name} quit`;
+    let stopCommand;
+    if (serverConfig.protocol === 'winrm') {
+      stopCommand = `taskkill /IM ${serverConfig.screen_name}.exe /F`;
+    } else {
+      stopCommand = `screen -X -S ${serverConfig.screen_name} quit`;
+    }
     return this.executeCommand(serverName, stopCommand);
   }
 
@@ -218,29 +253,37 @@ class SSHOperations {
       };
     }
     
-    const statusCommand = 'screen -ls';
+    const statusCommand = serverConfig.protocol === 'winrm'
+      ? `tasklist | findstr /I ${serverConfig.screen_name}`
+      : 'screen -ls';
     const result = await this.executeCommand(serverName, statusCommand, 500);
 
     if (!result.success) {
       return { success: false, sshDown: true };
     }
     
+    if (serverConfig.protocol === 'winrm') {
+      return {
+        success: true,
+        status: result.output && result.output.trim().length > 0
+      };
+    }
+
     // Parse and cache all screen sessions for this host
     if (!this.screenSessionCache) {
       this.screenSessionCache = {};
     }
-    
+
     // Extract all session names from the screen -ls output
     const screenSessions = [];
     const lines = result.output.split('\n');
     for (const line of lines) {
-      // Look for lines containing screen session info
       const match = line.match(/\d+\.([^\s\t]+)/); // Extracts session name
       if (match && match[1]) {
         screenSessions.push(match[1]);
       }
     }
-    
+
     // Cache the results
     this.screenSessionCache[host] = {
       timestamp: now,
@@ -250,7 +293,7 @@ class SSHOperations {
     debugLog(
       `${serverName}: sessions on ${host} -> ${screenSessions.join(', ')}`
     );
-    
+
     return {
       success: true,
       status: screenSessions.includes(serverConfig.screen_name)
@@ -269,13 +312,20 @@ class SSHOperations {
     }
     
     debugLog(`Batch status for host ${host} using ${serverName}`);
-    const statusCommand = 'screen -ls';
+    const serverConfig = this.config[serverName];
+    const statusCommand = serverConfig.protocol === 'winrm'
+      ? `tasklist | findstr /I ${serverConfig.screen_name}`
+      : 'screen -ls';
     const result = await this.executeCommand(serverName, statusCommand, 500);
     
     if (!result.success) {
       return { success: false, sshDown: true, host };
     }
     
+    if (serverConfig.protocol === 'winrm') {
+      return { success: true, host, sessions: result.output ? [serverConfig.screen_name] : [] };
+    }
+
     // Extract all session names from the screen -ls output
     const screenSessions = [];
     const lines = result.output.split('\n');
@@ -285,7 +335,7 @@ class SSHOperations {
         screenSessions.push(match[1]);
       }
     }
-    
+
     // Cache the results
     const now = Date.now();
     if (!this.screenSessionCache) {
@@ -296,7 +346,7 @@ class SSHOperations {
       sessions: screenSessions
     };
     debugLog(`Host ${host} sessions: ${screenSessions.join(', ')}`);
-    
+
     return { success: true, host, sessions: screenSessions };
   }
   
@@ -319,13 +369,20 @@ class SSHOperations {
   
   async getServerLog(serverName, lines = 200) {
     const serverConfig = this.config[serverName];
-    const logPath = path.join('.afl', `${serverConfig.screen_name}.screenlog`);
-    const logCommand = `tail -n ${lines} $\{HOME}/${logPath}`;
+    const logPath = serverConfig.protocol === 'winrm'
+      ? `C:\\afl\\${serverConfig.screen_name}.log`
+      : path.join('.afl', `${serverConfig.screen_name}.screenlog`);
+    const logCommand = serverConfig.protocol === 'winrm'
+      ? `Get-Content -Path ${logPath} -Tail ${lines}`
+      : `tail -n ${lines} $\{HOME}/${logPath}`;
     return this.executeCommand(serverName, logCommand);
   }
 
   async joinServer(serverName) {
     const serverConfig = this.config[serverName];
+    if (serverConfig.protocol === 'winrm') {
+      return { success: false, error: 'Join not supported on Windows hosts' };
+    }
     const joinCommand = `screen -x ${serverConfig.screen_name}`;
     return this.executeCommand(serverName, joinCommand);
   }
@@ -340,6 +397,12 @@ class SSHOperations {
     const server = this.getServerForHost(host);
     if (!server) return { success: false, error: `No server for host ${host}` };
     console.log(`Reading remote file ${remotePath} from ${host}`);
+    if (server.protocol === 'winrm') {
+      const cmd = `Get-Content -Path ${remotePath}`;
+      const res = await this.executeCommand(server.name || host, cmd);
+      if (res.success) return { success: true, data: res.output };
+      return res;
+    }
     return new Promise((resolve) => {
       const conn = new Client();
       conn.on('ready', () => {
@@ -377,6 +440,12 @@ class SSHOperations {
     const server = this.getServerForHost(host);
     if (!server) return { success: false, error: `No server for host ${host}` };
     console.log(`Writing remote file ${remotePath} to ${host}`);
+    if (server.protocol === 'winrm') {
+      const encoded = Buffer.from(content).toString('base64');
+      const ps = `Set-Content -Path ${remotePath} -Value ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${encoded}'))) -Force`;
+      const res = await this.executeCommand(server.name || host, ps);
+      return res.success ? { success: true } : res;
+    }
     return new Promise((resolve) => {
       const conn = new Client();
       conn.on('ready', () => {
@@ -416,7 +485,9 @@ class SSHOperations {
   async getRemoteAflConfig(host) {
     const server = this.getServerForHost(host);
     if (!server) return { success: false, error: `No server for host ${host}` };
-    const remotePath = `/home/${server.username}/.afl/config.json`;
+    const remotePath = server.protocol === 'winrm'
+      ? `C:\\Users\\${server.username}\\.afl\\config.json`
+      : `/home/${server.username}/.afl/config.json`;
     const res = await this.readRemoteFile(host, remotePath);
     if (!res.success) return res;
     try {
@@ -432,7 +503,9 @@ class SSHOperations {
   async saveRemoteAflConfig(host, cfgObj) {
     const server = this.getServerForHost(host);
     if (!server) return { success: false, error: `No server for host ${host}` };
-    const remotePath = `/home/${server.username}/.afl/config.json`;
+    const remotePath = server.protocol === 'winrm'
+      ? `C:\\Users\\${server.username}\\.afl\\config.json`
+      : `/home/${server.username}/.afl/config.json`;
     console.log(`Saving AFL config to ${remotePath} on ${host}`);
     let existing = {};
     const read = await this.readRemoteFile(host, remotePath);


### PR DESCRIPTION
## Summary
- allow remote management of Windows servers via WinRM
- install `nodejs-winrm` dependency
- document Windows support in README

## Testing
- `npm install`
- `npm audit fix`
- `npm run check-package`


------
https://chatgpt.com/codex/tasks/task_e_685322325cb0832b9f7e2d20113fb521