### PR TITLE
Simplify build outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ npm run build
 ```
 
 See `package.json` for platform-specific build scripts.
+The CI workflow produces installers for each OS:
+* macOS: DMG
+* Linux: AppImage
+* Windows: NSIS exe

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "electron .",
     "dev": "electron . --debug",
     "build": "electron-builder",
-    "build:win": "electron-builder --win",
-    "build:mac": "electron-builder --mac",
-    "build:linux": "electron-builder --linux",
+    "build:win": "electron-builder --win nsis",
+    "build:mac": "electron-builder --mac dmg",
+    "build:linux": "electron-builder --linux AppImage",
     "check-package": "node scripts/validate-package.js"
   },
   "repository": {
@@ -44,6 +44,7 @@
     "appId": "gov.nist.AFL-andon",
     "productName": "AFL Andon",
     "mac": {
+      "target": ["dmg"],
       "category": "public.app-category.utilities",
       "icon": "assets/icons/mac/icon.icns"
     },
@@ -54,10 +55,7 @@
       "icon": "assets/icons/win/icon.ico"
     },
     "linux": {
-      "target": [
-        "AppImage",
-        "deb"
-      ],
+      "target": ["AppImage"],
       "icon": "assets/icons/png/512x512.png",
       "category": "Utility"
     }


### PR DESCRIPTION
## Summary
- restrict electron-builder scripts to single target for each OS
- update build config in `package.json` to only produce DMG, AppImage or NSIS
- document CI outputs in README

## Testing
- `npm run check-package`
- `npm run build:linux -- --dir`

------
https://chatgpt.com/codex/tasks/task_e_68558ae893c0832ba25afdd015af4c94